### PR TITLE
fix: Ensure presence of /etc/resolver/ folder by creating it

### DIFF
--- a/libexec/zas-install
+++ b/libexec/zas-install
@@ -22,6 +22,7 @@ launchctl kickstart -k gui/"$UID"/com.zas.zasd 2>/dev/null
 # Install DNS resolver
 
 echo "Installing DNS resolver"
+sudo mkdir -p /etc/resolver/
 sudo cp -f "$ZAS_ROOT/resources/dev-resolver" /etc/resolver/dev
 
 # Install port forwarding


### PR DESCRIPTION
Prevents the absence of the `/etc/resolver` folder, which will cause errors on installing 
